### PR TITLE
fixes a typo in the handshake (missing comma)

### DIFF
--- a/bayeux/bayeux_message_sender.py
+++ b/bayeux/bayeux_message_sender.py
@@ -79,7 +79,7 @@ class BayeuxMessageSender(object):
                 during sending.
         """
         message = '''message={{"channel":"{0}","id":"{1}",
-            "supportedConnectionTypes":["callback-polling" "long-polling"],
+            "supportedConnectionTypes":["callback-polling", "long-polling"],
             "version":"1.0","minimumVersion":"1.0"}}'''.format(
                 bayeux_constants.HANDSHAKE_CHANNEL,
                 self.get_next_id())


### PR DESCRIPTION
Line 82 was missing a comma in the list of supported connection types.
